### PR TITLE
Bug removals and a newly added feature.

### DIFF
--- a/mcc/Dispatcher.c
+++ b/mcc/Dispatcher.c
@@ -61,7 +61,7 @@ void ResetDisplay(struct InstData *data)
   if(data->shown == TRUE)
   {
     data->totallines = CountLines(data, &data->linelist);
-    data->longestline = LongestLine(data);
+    data->longestline = data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap ? LongestLine(data) : _mwidth(data->object);
     GetColor(data, data->CPos_X, data->actualline, &data->Pen);
     data->Flow = data->actualline->line.Flow;
     data->Separator = data->actualline->line.Separator;
@@ -158,6 +158,7 @@ static IPTR mNew(struct IClass *cl, Object *obj, struct opSet *msg)
             data->GlobalTabSize = 4; // default to 4 spaces per TAB
             data->TabSizePixels = 4*8; // assume a fixed space width of 8 pixels per default
             data->ConvertTabs = TRUE; // convert tab to spaces per default
+            data->SliderBehaviour = MUIV_TextEditor_Slider_Standard;
 
             data->ExportHook = &ExportHookPlain;
             setFlag(data->flags, FLG_AutoClip);
@@ -978,7 +979,7 @@ DISPATCHER(_Dispatcher)
   if(t_haschanged != data->HasChanged)
     set(obj, MUIA_TextEditor_HasChanged, data->HasChanged);
 
-  if(data->ChangeEvent)
+  if(data->ChangeEvent && data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap)
   {
     data->longestline = LongestLine(data);
     data->ChangeEvent = FALSE;
@@ -1010,7 +1011,7 @@ DISPATCHER(_Dispatcher)
               TAG_DONE);
 
     // visual_y is changed it is best to recalculate longest visible line here
-    if(data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap)
+    if(data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap && data->SliderBehaviour == MUIV_TextEditor_Slider_MUI)
        data->longestline = LongestLine(data);
   }
 

--- a/mcc/Dispatcher.c
+++ b/mcc/Dispatcher.c
@@ -158,7 +158,7 @@ static IPTR mNew(struct IClass *cl, Object *obj, struct opSet *msg)
             data->GlobalTabSize = 4; // default to 4 spaces per TAB
             data->TabSizePixels = 4*8; // assume a fixed space width of 8 pixels per default
             data->ConvertTabs = TRUE; // convert tab to spaces per default
-            data->SliderBehaviour = MUIV_TextEditor_Slider_Standard;
+          //data->SliderBehaviour = MUIV_TextEditor_Slider_Standard;
 
             data->ExportHook = &ExportHookPlain;
             setFlag(data->flags, FLG_AutoClip);
@@ -1010,9 +1010,9 @@ DISPATCHER(_Dispatcher)
               MUIA_TextEditor_Prop_First, (data->visual_y-1)*data->fontheight,
               TAG_DONE);
 
-    // visual_y is changed it is best to recalculate longest visible line here
+    /* visual_y is changed it is best to recalculate longest visible line here
     if(data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap && data->SliderBehaviour == MUIV_TextEditor_Slider_MUI)
-       data->longestline = LongestLine(data);
+       data->longestline = LongestLine(data); */
   }
 
   if(data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap && data->hslider)

--- a/mcc/GetSetAttrs.c
+++ b/mcc/GetSetAttrs.c
@@ -673,6 +673,10 @@ IPTR mSet(struct IClass *cl, Object *obj, struct opSet *msg)
       }
       break;
 
+      case MUIA_TextEditor_Slider_Behaviour:
+        data->SliderBehaviour = ti_Data;
+      break;
+
       case MUIA_TextEditor_FixedFont:
       {
         if(data->shown == FALSE)

--- a/mcc/GetSetAttrs.c
+++ b/mcc/GetSetAttrs.c
@@ -673,9 +673,9 @@ IPTR mSet(struct IClass *cl, Object *obj, struct opSet *msg)
       }
       break;
 
-      case MUIA_TextEditor_Slider_Behaviour:
+  /*  case MUIA_TextEditor_Slider_Behaviour:
         data->SliderBehaviour = ti_Data;
-      break;
+      break;                                 */
 
       case MUIA_TextEditor_FixedFont:
       {

--- a/mcc/MixedFunctions.c
+++ b/mcc/MixedFunctions.c
@@ -810,14 +810,21 @@ LONG LongestLine(struct InstData *data)
   /* Since this function will be only used in NoWrapMode and
      in that mode line_nr's will always match the real lines
      we can find the top (real) line just by traversing the list */
-  while(line != NULL && line_nr != data->visual_y - 1)
-  {
-    line = GetNextLine(line);
-    line_nr++;
-  }
 
-  // Calculate the line_nr of the last line displayed
-  last_line = line_nr + data->maxlines - 1;
+  // Skip to first displayed line if SliderBehaviour is MUI
+  if(data->SliderBehaviour == MUIV_TextEditor_Slider_MUI)
+  {
+    while(line != NULL && line_nr != data->visual_y - 1)
+    {
+      line = GetNextLine(line);
+      line_nr++;
+    }
+
+    // Calculate the line_nr of the last line displayed
+    last_line = line_nr + data->maxlines - 1;
+  }
+  else
+    last_line = data->totallines -1;
 
   /* We found the top line displayed. Now we'll traverse until the
      last displayed line meanwhile calculating their pixel lengths */

--- a/mcc/MixedFunctions.c
+++ b/mcc/MixedFunctions.c
@@ -811,7 +811,7 @@ LONG LongestLine(struct InstData *data)
      in that mode line_nr's will always match the real lines
      we can find the top (real) line just by traversing the list */
 
-  // Skip to first displayed line if SliderBehaviour is MUI
+  /* Skip to first displayed line if SliderBehaviour is MUI
   if(data->SliderBehaviour == MUIV_TextEditor_Slider_MUI)
   {
     while(line != NULL && line_nr != data->visual_y - 1)
@@ -823,7 +823,7 @@ LONG LongestLine(struct InstData *data)
     // Calculate the line_nr of the last line displayed
     last_line = line_nr + data->maxlines - 1;
   }
-  else
+  else */
     last_line = data->totallines -1;
 
   /* We found the top line displayed. Now we'll traverse until the

--- a/mcc/PrintLineWithStyles.c
+++ b/mcc/PrintLineWithStyles.c
@@ -359,7 +359,7 @@ LONG PrintLine(struct InstData *data, LONG x, struct line_node *line, LONG line_
     pen_pos  = xoffset + flow;
     o_width  = ((ULONG)flow > data->xpos ? 0 : data->xpos - flow);
     maxwidth = data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap ?
-              (MIN((_mwidth(data->object) + data->xpos - flow + rp->TxWidth), (ULONG)TextLengthNew(rp, text+x, c_length, data->TabSizePixels))) :
+              (MIN((_mwidth(data->object) + data->xpos - flow + rp->TxHeight), (ULONG)TextLengthNew(rp, text+x, c_length, data->TabSizePixels)))+1 :
                     _mwidth(data->object) - flow; 
 
     while(c_length > 0)
@@ -438,11 +438,19 @@ LONG PrintLine(struct InstData *data, LONG x, struct line_node *line, LONG line_
             else
               TextNew(rp, text+x+o_chars, fitting, data->TabSizePixels);
 
+            // immediately bail out if end of line is reached
+            if(p_length +1 == length)
+            {
+              pen_pos += te.te_Width;
+              x += p_length;
+            break;
+            }
+
             pen_pos += te.te_Width;
           }
 
           // adjust the available horizontal pixel space
-          maxwidth -= te.te_Width;
+          maxwidth = fitting < (p_length - o_chars) ? 0 : maxwidth - te.te_Width;
         }
 
         // add the length calculated before no matter how many character really fitted
@@ -461,7 +469,7 @@ LONG PrintLine(struct InstData *data, LONG x, struct line_node *line, LONG line_
       LeftX = dleft;
       LeftWidth = flow - data->xpos - 3;
       LeftWidth = LeftWidth < 0 ? 0 : LeftWidth;
-      RightX = pen_pos - _mleft(data->object) + 4;
+      RightX = pen_pos + 3;
       RightX = RightX < dleft ? dleft : RightX;
       RightWidth = dright > RightX ? dright - RightX : _mwidth(data->object);
       Y = starty;

--- a/mcc/private.h
+++ b/mcc/private.h
@@ -146,11 +146,11 @@
 #define MUIA_TextEditor_HSlider_Pos        (TextEditor_Dummy + 0x47)
 #define MUIA_TextEditor_HSlider_Vis        (TextEditor_Dummy + 0x48)
 #define MUIA_TextEditor_HSlider_Ent        (TextEditor_Dummy + 0x49)
-#define MUIA_TextEditor_Slider_Behaviour   (TextEditor_Dummy + 0x50)
+// #define MUIA_TextEditor_Slider_Behaviour   (TextEditor_Dummy + 0x50)
 
 // private/experimental attribute values
-#define MUIV_TextEditor_Slider_Standard    0x00000000UL
-#define MUIV_TextEditor_Slider_MUI         0x00000001UL
+// #define MUIV_TextEditor_Slider_Standard    0x00000000UL
+// #define MUIV_TextEditor_Slider_MUI         0x00000001UL
 
 // special flagging macros
 #define setFlag(mask, flag)             (mask) |= (flag)               // set the flag "flag" in "mask"
@@ -468,7 +468,10 @@ struct InstData
                              then will be used as a notification to recalculate the longestline in the Dispatcher
                              and immediately set back to FALSE */
   Object *hslider;        // pointer to the horizontal scrollbar (if any).
-  ULONG  SliderBehaviour; // MUIV_TextEditor_Slider_Standard or MUIV_TextEditor_Slider_MUI
+
+//ULONG  SliderBehaviour; // Makes horizontal scrollers behave the way they behave in NList class gadgets.
+                          // This feature is currently disabled! To re-enable it search "Behaviour" phrase inside:
+                          // this file, Dispatcher.c, GetSetAttrs.c, MixedFunctions.c and un-comment related sections.
 };
 
 // AllocBitMap.c

--- a/mcc/private.h
+++ b/mcc/private.h
@@ -146,6 +146,11 @@
 #define MUIA_TextEditor_HSlider_Pos        (TextEditor_Dummy + 0x47)
 #define MUIA_TextEditor_HSlider_Vis        (TextEditor_Dummy + 0x48)
 #define MUIA_TextEditor_HSlider_Ent        (TextEditor_Dummy + 0x49)
+#define MUIA_TextEditor_Slider_Behaviour   (TextEditor_Dummy + 0x50)
+
+// private/experimental attribute values
+#define MUIV_TextEditor_Slider_Standard    0x00000000UL
+#define MUIV_TextEditor_Slider_MUI         0x00000001UL
 
 // special flagging macros
 #define setFlag(mask, flag)             (mask) |= (flag)               // set the flag "flag" in "mask"
@@ -457,12 +462,13 @@ struct InstData
   ULONG  xpos;            /* xpos of gadget (for horizontal scrolling)
                              unlike visual_y this is a pixel value... */
   LONG   longestline;     /* the length (in pixels) of the longest one of the lines displayed
-                             (this is used as the Prop_Entries value for the hslider) */
+                             (this is used as the Prop_Entries value for the hslider)
+                             NOTE: Only valid in NoWrapMode (is equal to _mwidth in other modes)  */
   BOOL   ChangeEvent;     /* Everytime something is changed in the text, this will be set TRUE along with HasChanged
                              then will be used as a notification to recalculate the longestline in the Dispatcher
                              and immediately set back to FALSE */
   Object *hslider;        // pointer to the horizontal scrollbar (if any).
-
+  ULONG  SliderBehaviour; // MUIV_TextEditor_Slider_Standard or MUIV_TextEditor_Slider_MUI
 };
 
 // AllocBitMap.c


### PR DESCRIPTION
BUGS: In PrintLineWithStyles.c, PrintLine() function:

Previous calculation of maxwidth variable was causing glitches with larger font sizes. This is corrected. (361 and 453)
A long existing implicit bug in text printing loop, which revealed itself with the horizontal scrolling implementation now removed. (376)
A calculation mistake in separator drawing corrected. (472)
FEATURE: 
A new private attribute MUIA_TextEditor_Slider_Behaviour added with two values:
MUIV_TextEditor_Slider_Standard
MUIA_TextEditor_Slider_MUI.

In standard mode the horizontal scroller reflects the current longest line within all text (as all modern text editors do).
In MUI mode it reflects the longest line within FOV (Field Of View).
