### PR TITLE
Separator bug removed and bottom space usage added.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,19 @@
 MUI TextEditor MCC class - ChangeLog
 ------------------------------------
 
+2016-11-08 Alper Sönmez <amithlondestek@gmail.com>
+
+  * mcc/EditorStuff.c: Corrected raster scroll in accordance with bottom space
+    usage.
+  * mcc/GetSetAttrs.c: Corrected line dump in accordance w. bottom space usage.
+  * mcc/HandleInput.c, mcc/Methods.c:
+    Implemented new behaviour for user clicks in the bottom space.
+  * mcc/MixedFunctions.c: Better cursor drawing and drawbottom evaluations and
+    tweaks for bottom space usage
+  * mcc/Navigation.c : Tweaks for bottom space usage.
+  * mcc/PrintLinesWithStyles.c: A bug in separator drawing removed. Better
+    evaluation for partial line drawing in double buffer mode.
+
 2016-11-03 Alper Sönmez <amithlondestek@gmail.com>
 
   * mcc/Methods.c: horizontal autoscroll when block marking implemented.

--- a/mcc/EditorStuff.c
+++ b/mcc/EditorStuff.c
@@ -1050,7 +1050,7 @@ BOOL SplitLine(struct InstData *data, LONG x, struct line_node *line, BOOL move_
           oldhook = InstallLayerHook(data->rport->Layer, LAYERS_NOBACKFILL);
           ScrollRasterBF(data->rport, 0, data->fontheight,
                     _mleft(data->object), data->ypos,
-                    _mright(data->object), (data->ypos + ((data->maxlines-1) * data->fontheight)) - 1);
+                    _mright(data->object), _mbottom(data->object));
           InstallLayerHook(data->rport->Layer, oldhook);
 
           PrintLine(data, 0, line, data->maxlines-1, FALSE);

--- a/mcc/GetSetAttrs.c
+++ b/mcc/GetSetAttrs.c
@@ -403,7 +403,7 @@ IPTR mSet(struct IClass *cl, Object *obj, struct opSet *msg)
               }
             }
 
-            DumpText(data, data->visual_y+line_nr, line_nr, data->maxlines+2, FALSE);
+            DumpText(data, data->visual_y+line_nr, line_nr, data->maxlines+1, FALSE);
           }
           else
           {

--- a/mcc/HandleInput.c
+++ b/mcc/HandleInput.c
@@ -970,7 +970,7 @@ IPTR mHandleInput(struct IClass *cl, Object *obj, struct MUIP_HandleEvent *msg)
               if(imsg->MouseX >= _left(obj) &&
                  imsg->MouseX <= _right(obj) &&
                  imsg->MouseY >= data->ypos &&
-                 imsg->MouseY <  data->ypos+(data->maxlines * data->fontheight))
+                 imsg->MouseY < _bottom(obj))
               {
                 if(isFlagClear(data->flags, FLG_Active) &&
                    isFlagClear(data->flags, FLG_Activated) &&
@@ -994,6 +994,10 @@ IPTR mHandleInput(struct IClass *cl, Object *obj, struct MUIP_HandleEvent *msg)
                   setFlag(data->flags, FLG_Activated);
                   SetCursor(data, data->CPos_X, data->actualline, FALSE);
                   PosFromCursor(data, imsg->MouseX, imsg->MouseY);
+
+                  // if the user clicked the partially displayed line at the bottom : make it totally visible
+                  if(imsg->MouseY > data->ypos+(data->maxlines * data->fontheight))
+                    ScrollIntoDisplay(data);
 
                   if(isFlagSet(imsg->Qualifier, IEQUALIFIER_LSHIFT) || isFlagSet(imsg->Qualifier, IEQUALIFIER_RSHIFT))
                     data->selectmode = 0;
@@ -1541,8 +1545,8 @@ void MarkText(struct InstData *data, LONG x1, struct line_node *line1, LONG x2, 
     line_nr1 = 0;
 
   line_nr2 += pos2.lines-1;
-  if(line_nr2 >= data->maxlines)
-    line_nr2 = data->maxlines-1;
+  if(line_nr2 > data->maxlines)
+    line_nr2 = data->maxlines;
 
   if(line_nr1 <= line_nr2)
     DumpText(data, data->visual_y+line_nr1, line_nr1, line_nr2+1, FALSE);

--- a/mcc/Methods.c
+++ b/mcc/Methods.c
@@ -270,9 +270,13 @@ IPTR mInputTrigger(struct IClass *cl, Object *obj, UNUSED Msg msg)
       LONG limit = data->ypos;
 
       if(data->maxlines < (data->totallines-data->visual_y+1))
-        limit += (data->maxlines * data->fontheight);
+        limit += ((data->maxlines+1) * data->fontheight);
       else
         limit += (data->totallines-data->visual_y+1)*data->fontheight;
+
+      // if the user clicked the partially displayed line at the bottom (to prevent a non-stop scroll down)
+      if(MouseY < data->ypos+_mheight(data->object) && MouseY > data->ypos+(data->maxlines * data->fontheight))
+        MouseY -= data->fontheight;
 
       if(MouseY >= limit)
       {

--- a/mcc/MixedFunctions.c
+++ b/mcc/MixedFunctions.c
@@ -467,7 +467,7 @@ void SetCursor(struct InstData *data, LONG x, struct line_node *line, BOOL Set)
   line_nr = LineToVisual(data, line) - 1;
   OffsetToLines(data, x, line, &pos);
 
-  if(line_nr + pos.lines <= data->maxlines +1 && line_nr + pos.lines > 0)
+  if(line_nr + pos.lines <= data->maxlines+1 && line_nr + pos.lines > 0)
   {
     for(c = -1; c < 2; c++)
     {

--- a/mcc/MixedFunctions.c
+++ b/mcc/MixedFunctions.c
@@ -467,7 +467,7 @@ void SetCursor(struct InstData *data, LONG x, struct line_node *line, BOOL Set)
   line_nr = LineToVisual(data, line) - 1;
   OffsetToLines(data, x, line, &pos);
 
-  if(line_nr + pos.lines <= data->maxlines && line_nr + pos.lines > 0)
+  if(line_nr + pos.lines <= data->maxlines +1 && line_nr + pos.lines > 0)
   {
     for(c = -1; c < 2; c++)
     {
@@ -497,10 +497,16 @@ void SetCursor(struct InstData *data, LONG x, struct line_node *line, BOOL Set)
     yplace  = data->ypos + (data->fontheight * (line_nr + pos.lines - 1));
     cursorxplace = xplace + TextLengthNew(&data->tmprp, &line->line.Contents[x+start], 0-start, data->TabSizePixels);
 
-    // do not do any draw operations if in NoWrap mode and the cursor is out of field of view (even partially)
+    // do not do draw operations under some contitions if in NoWrap mode 
     if(data->WrapMode == MUIV_TextEditor_WrapMode_NoWrap)
-      if(cursorxplace < _mleft(data->object) || (cursorxplace + cursor_width) > _mright(data->object))
+    {
+      // do not draw the cursor if it is not in the field of view (even partially)
+      if(Set == TRUE && (cursorxplace < _mleft(data->object) || (cursorxplace + cursor_width - 1) > _mright(data->object)))
         return;
+      // do not clear the cursor it is not in the field of view (totally)
+      else if(Set == FALSE && ((cursorxplace + cursor_width - 1) < _mleft(data->object) || cursorxplace > _mright(data->object)))
+        return;
+    }
 
     //D(DBF_STARTUP, "xplace: %ld, yplace: %ld cplace: %ld, innerwidth: %ld width: %ld %ld", xplace, yplace, cursorxplace, _mwidth(data->object), _width(data->object), _mleft(data->object));
 
@@ -627,9 +633,15 @@ void DumpText(struct InstData *data, LONG visual_y, LONG line_nr, LONG lines, BO
   struct line_node *line;
   LONG x;
   LONG y_smoothFix = _mtop(data->object) - data->ypos;
-  BOOL drawbottom = ((data->maxlines * data->fontheight) < _mheight(data->object) && y_smoothFix == 0) || (visual_y + lines - line_nr - 1) > data->totallines;
+  BOOL drawbottom;
 
   ENTER();
+
+  // if the gadget height is not proportional to fontheight print one more line to be partially visible at the bottom
+  if((data->maxlines * data->fontheight) < _mheight(data->object))
+    lines++;
+
+  drawbottom = (visual_y + lines - line_nr - 1) > data->totallines;
 
   if(data->update == TRUE && data->shown == TRUE && isFlagClear(data->flags, FLG_Quiet))
   {
@@ -637,7 +649,7 @@ void DumpText(struct InstData *data, LONG visual_y, LONG line_nr, LONG lines, BO
     line = pos.line;
     x = pos.x;
 
-    if(lines-line_nr < 3 || doublebuffer == TRUE)
+    if(doublebuffer == TRUE || lines-line_nr < 3 || lines > data->maxlines)
     {
       doublebuffer = TRUE;
     }

--- a/mcc/Navigation.c
+++ b/mcc/Navigation.c
@@ -680,7 +680,7 @@ void PosFromCursor(struct InstData *data, LONG MouseX, LONG MouseY)
   ENTER();
 
   if(data->maxlines < data->totallines-data->visual_y+1)
-    limit += (data->maxlines * data->fontheight);
+    limit += ((data->maxlines+1) * data->fontheight);
   else
     limit += (data->totallines-data->visual_y+1)*data->fontheight;
 

--- a/mcc/PrintLineWithStyles.c
+++ b/mcc/PrintLineWithStyles.c
@@ -546,7 +546,7 @@ LONG PrintLine(struct InstData *data, LONG x, struct line_node *line, LONG line_
       else
       {
 
-        if (data->ypos+(data->fontheight * line_nr) > _mbottom(data->object))
+        if(data->ypos+(data->fontheight * line_nr) > _mbottom(data->object))
         {
           BltBitMapRastPort(rp->BitMap, 0, 0, data->rport, _mleft(data->object), data->ypos+(data->fontheight * (line_nr-1)), _mwidth(data->object), _mbottom(data->object) - data->ypos - (data->fontheight * (line_nr-1))+1, (ABC|ABNC));
         }

--- a/mcc/PrintLineWithStyles.c
+++ b/mcc/PrintLineWithStyles.c
@@ -100,15 +100,18 @@ void DrawSeparator(struct InstData *data, struct RastPort *rp, LONG X, LONG Y, L
 {
   ENTER();
 
-  if(Width > 3*Height)
+  if(data->doublerp || (Y > _top(data->object) && Y+Height < _bottom(data->object)))
   {
-    SetAPen(rp, MUIPEN(data->separatorshadow));
-    RectFill(rp, X, Y, X+Width-2, Y);
-    RectFill(rp, X, Y, X, Y+Height);
+    if(Width > 3*Height)
+    {
+      SetAPen(rp, MUIPEN(data->separatorshadow));
+      RectFill(rp, X, Y, X+Width-2, Y);
+      RectFill(rp, X, Y, X, Y+Height);
 
-    SetAPen(rp, MUIPEN(data->separatorshine));
-    RectFill(rp, X+1, Y+Height, X+Width-1, Y+Height);
-    RectFill(rp, X+Width-1, Y, X+Width-1, Y+Height);
+      SetAPen(rp, MUIPEN(data->separatorshine));
+      RectFill(rp, X+1, Y+Height, X+Width-1, Y+Height);
+      RectFill(rp, X+Width-1, Y, X+Width-1, Y+Height);
+    }
   }
 
   LEAVE();
@@ -542,12 +545,10 @@ LONG PrintLine(struct InstData *data, LONG x, struct line_node *line, LONG line_
       }
       else
       {
-        if(line_nr == data->maxlines+1)
+
+        if (data->ypos+(data->fontheight * line_nr) > _mbottom(data->object))
         {
-          if(_mtop(data->object) != data->ypos)
-          {
-            BltBitMapRastPort(rp->BitMap, 0, 0, data->rport, _mleft(data->object), data->ypos+(data->fontheight * (line_nr-1)), _mwidth(data->object), _mtop(data->object)-data->ypos, (ABC|ABNC));
-          }
+          BltBitMapRastPort(rp->BitMap, 0, 0, data->rport, _mleft(data->object), data->ypos+(data->fontheight * (line_nr-1)), _mwidth(data->object), _mbottom(data->object) - data->ypos - (data->fontheight * (line_nr-1))+1, (ABC|ABNC));
         }
         else
         {


### PR DESCRIPTION
* mcc/EditorStuff.c: Corrected raster scrolling in accordance with bottom space usage.
* mcc/GetSetAttrs.c: Corrected line dump in accordance with bottom space usage.
* mcc/HandleInput.c: Implemented new behaviour for user clicks in the bottom space.
* mcc/Methods.c: Implemented new behaviour for user clicks in the bottom space.
* mcc/MixedFunctions.c: Better cursor drawing and drawbottom evaluations and tweaks for bottom space usage
* mcc/Navigation.c : Tweaks for bottom space usage.
* mcc/PrintLinesWithStyles.c: A bug in separator drawing removed. Better evaluation for partial line drawing in double buffer mode.

Removes issue #16 